### PR TITLE
disabled aria-allowed-attr axe rule

### DIFF
--- a/src/app/public/a11y/a11y-analyzer.ts
+++ b/src/app/public/a11y/a11y-analyzer.ts
@@ -7,7 +7,7 @@ export abstract class SkyA11yAnalyzer {
     rules: {
       'accesskeys': { enabled: true },
       'area-alt': { enabled: true },
-      'aria-allowed-attr': { enabled: true },
+      'aria-allowed-attr': { enabled: false }, // TEMP: this should be re-enabled when we upgrade to axe-core ^3.1.1
       'aria-required-attr': { enabled: true },
       'aria-required-children': { enabled: true },
       'aria-required-parent': { enabled: true },

--- a/src/app/public/a11y/a11y-analyzer.ts
+++ b/src/app/public/a11y/a11y-analyzer.ts
@@ -7,7 +7,9 @@ export abstract class SkyA11yAnalyzer {
     rules: {
       'accesskeys': { enabled: true },
       'area-alt': { enabled: true },
-      'aria-allowed-attr': { enabled: false }, // TODO: this should be re-enabled when we upgrade to axe-core ^3.1.1 (https://github.com/dequelabs/axe-core/issues/961)
+
+      // TODO: this should be re-enabled when we upgrade to axe-core ^3.1.1 (https://github.com/dequelabs/axe-core/issues/961)
+      'aria-allowed-attr': { enabled: false },
       'aria-required-attr': { enabled: true },
       'aria-required-children': { enabled: true },
       'aria-required-parent': { enabled: true },

--- a/src/app/public/a11y/a11y-analyzer.ts
+++ b/src/app/public/a11y/a11y-analyzer.ts
@@ -7,7 +7,7 @@ export abstract class SkyA11yAnalyzer {
     rules: {
       'accesskeys': { enabled: true },
       'area-alt': { enabled: true },
-      'aria-allowed-attr': { enabled: false }, // TEMP: this should be re-enabled when we upgrade to axe-core ^3.1.1
+      'aria-allowed-attr': { enabled: false }, // TODO: this should be re-enabled when we upgrade to axe-core ^3.1.1 (https://github.com/dequelabs/axe-core/issues/961)
       'aria-required-attr': { enabled: true },
       'aria-required-children': { enabled: true },
       'aria-required-parent': { enabled: true },


### PR DESCRIPTION
This should remain disabled until we can upgrade to using axe-core 3.1.1. The current version does not recognize certain attributes as appropriate for certain roles that we use together and will cause failures to this rule.