### PR TITLE
feat: add pageobject class

### DIFF
--- a/src/app/public/test-utility/page-object.spec.ts
+++ b/src/app/public/test-utility/page-object.spec.ts
@@ -1,0 +1,58 @@
+import {
+  DebugElement
+} from '@angular/core';
+
+import {
+  ComponentFixture
+} from '@angular/core/testing';
+
+import {
+  PageObject
+} from './page-object';
+
+// this is solely here to test typing.
+class ParentComponent {
+}
+
+class ChildComponent {
+}
+
+describe('PageObject', () => {
+  let fixture: any;
+  let page: PageObject<ParentComponent>;
+
+  beforeEach(() => {
+    fixture = {
+      nativeElement: jasmine.createSpyObj('nativeElement', ['querySelector', 'querySelectorAll']),
+      debugElement: jasmine.createSpyObj('debugElement', ['query'])
+    };
+    page = new PageObject<ParentComponent>(fixture as ComponentFixture<ParentComponent>);
+  });
+
+  it('should query HTMLElements based on selector', () => {
+    const selector: string = 'selector';
+    const element: HTMLElement = {} as HTMLElement;
+    fixture.nativeElement.querySelector.and.returnValue(element);
+    const returnedElement: HTMLElement = page.querySelector(selector);
+    expect(returnedElement).toBe(element);
+    expect(fixture.nativeElement.querySelector).toHaveBeenCalledWith(selector);
+  });
+
+  it('should query all HTMLElements based on selector', () => {
+    const selector: string = 'selector';
+    const elements: NodeListOf<HTMLElement> = {} as NodeListOf<HTMLElement>;
+    fixture.nativeElement.querySelectorAll.and.returnValue(elements);
+    const returnedElements: NodeListOf<HTMLElement> = page.querySelectorAll(selector);
+    expect(returnedElements).toBe(elements);
+    expect(fixture.nativeElement.querySelectorAll).toHaveBeenCalledWith(selector);
+  });
+
+  it('should query components based on type', () => {
+    const childComponent = new ChildComponent();
+    const debugElement: DebugElement = {componentInstance: childComponent} as DebugElement;
+    fixture.debugElement.query.and.returnValue(debugElement);
+    const returnedComp: ChildComponent = page.queryDirective(ChildComponent);
+    expect(returnedComp).toBe(childComponent);
+    expect(fixture.debugElement.query).toHaveBeenCalledWith(jasmine.any(Function));
+  });
+});

--- a/src/app/public/test-utility/page-object.ts
+++ b/src/app/public/test-utility/page-object.ts
@@ -1,0 +1,28 @@
+import {
+  Type
+} from '@angular/core';
+
+import {
+  ComponentFixture
+} from '@angular/core/testing';
+
+import {
+  By
+} from '@angular/platform-browser';
+
+export class PageObject<C> {
+  public constructor(private fixture: ComponentFixture<C>) {
+  }
+
+  public queryDirective<T>(type: Type<T>): T {
+    return this.fixture.debugElement.query(By.directive(type)).componentInstance;
+  }
+
+  public querySelector<T extends HTMLElement>(selector: string): T {
+    return this.fixture.nativeElement.querySelector(selector);
+  }
+
+  public querySelectorAll<T extends HTMLElement>(selector: string): NodeListOf<T> {
+    return this.fixture.nativeElement.querySelectorAll(selector);
+  }
+}


### PR DESCRIPTION
this can be extended by consumers  in order to standardize how DOM
queries are made. 

for instance, 

```typescript
export class MyComponentPage extends PageObject<MyComponent> {
  public firstNameInput(): HTMLInputElement {
    return this.querySelector<HTMLInputElement>('input#first-name');
  }

  public lastNameInput(): HTMLElement {
    return this.querySelector<HTMLInputElement>('input#last-name');
  }
}
```