### PR TITLE
Must spread args before passing them to the resources service

### DIFF
--- a/src/app/public/matchers/matchers.spec.ts
+++ b/src/app/public/matchers/matchers.spec.ts
@@ -219,9 +219,10 @@ describe('Jasmine matchers', () => {
       const messageArgs: any[] = [100];
       const text = 'message from resources with args = 100';
 
-      spyOn(resourcesService, 'getString').and.callFake((name: string, args: any[]) => {
+      spyOn(resourcesService, 'getString').and.callFake((name: string, arg: string) => {
+        console.log('*** args', arg);
         if (name === messageKey) {
-          return observableOf(messageValue.replace('{0}', args[0]));
+          return observableOf(messageValue.replace('{0}', arg));
         } else {
           return EMPTY;
         }
@@ -296,9 +297,9 @@ describe('Jasmine matchers', () => {
       const messageArgs: any[] = [100];
       const elem = createElement(messageValue.replace('{0}', messageArgs[0]));
 
-      spyOn(resourcesService, 'getString').and.callFake((name: string, args: any[]) => {
+      spyOn(resourcesService, 'getString').and.callFake((name: string, arg: string) => {
         if (name === messageKey) {
-          return observableOf(messageValue.replace('{0}', args[0]));
+          return observableOf(messageValue.replace('{0}', arg));
         } else {
           return EMPTY;
         }
@@ -391,9 +392,9 @@ describe('Jasmine matchers', () => {
         const messageArgs: any[] = [100];
         const text = 'message from resources with args = 100';
 
-        spyOn(resourcesService, 'getString').and.callFake((name: string, args: any[]) => {
+        spyOn(resourcesService, 'getString').and.callFake((name: string, arg: string) => {
           if (name === messageKey) {
-            return observableOf(messageValue.replace('{0}', args[0]));
+            return observableOf(messageValue.replace('{0}', arg));
           } else {
             return EMPTY;
           }
@@ -458,9 +459,9 @@ describe('Jasmine matchers', () => {
         const messageArgs: any[] = [100];
         const elem = createElement(messageValue.replace('{0}', messageArgs[0]));
 
-        spyOn(resourcesService, 'getString').and.callFake((name: string, args: any[]) => {
+        spyOn(resourcesService, 'getString').and.callFake((name: string, arg: string) => {
           if (name === messageKey) {
-            return observableOf(messageValue.replace('{0}', args[0]));
+            return observableOf(messageValue.replace('{0}', arg));
           } else {
             return EMPTY;
           }

--- a/src/app/public/matchers/matchers.ts
+++ b/src/app/public/matchers/matchers.ts
@@ -1,18 +1,11 @@
-import {
-  TestBed
-} from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
-import {
-  SkyAppResourcesService
-} from '@skyux/i18n';
+import { SkyAppResourcesService } from '@skyux/i18n';
+import { Observable } from 'rxjs';
 
-import {
-  SkyA11yAnalyzer
-} from '../a11y/a11y-analyzer';
+import { SkyA11yAnalyzer } from '../a11y/a11y-analyzer';
 
-import {
-  SkyA11yAnalyzerConfig
-} from '../a11y/a11y-analyzer-config';
+import { SkyA11yAnalyzerConfig } from '../a11y/a11y-analyzer-config';
 
 const windowRef: any = window;
 
@@ -140,12 +133,10 @@ const matchers: jasmine.CustomMatcherFactories = {
           );
         });
 
-        const result = {
+        return {
           pass: !hasFailure,
           message: message.join('\n')
         };
-
-        return result;
       }
     };
   },
@@ -185,8 +176,7 @@ const matchers: jasmine.CustomMatcherFactories = {
         callback: () => void = () => {}
       ): jasmine.CustomMatcherResult {
 
-        let skyAppResourcesService = TestBed.inject(SkyAppResourcesService);
-        skyAppResourcesService.getString(name, ...args).toPromise().then(message => {
+        getResourcesObservable(name, args).toPromise().then(message => {
           if (actual !== message) {
             windowRef.fail(`Expected "${actual}" to equal "${message}"`);
             callback();
@@ -223,8 +213,7 @@ const matchers: jasmine.CustomMatcherFactories = {
           actual = actual.trim();
         }
 
-        let skyAppResourcesService = TestBed.inject(SkyAppResourcesService);
-        skyAppResourcesService.getString(name, ...args).toPromise().then(message => {
+        getResourcesObservable(name, args).toPromise().then(message => {
           if (actual !== message) {
             windowRef.fail(`Expected element's inner text to be "${message}"`);
             callback();
@@ -276,10 +265,9 @@ const asyncMatchers: jasmine.CustomAsyncMatcherFactories = {
         name: string,
         args?: any[]
       ): Promise<jasmine.CustomMatcherResult> {
-        const resourcesService: SkyAppResourcesService = TestBed.inject(SkyAppResourcesService);
 
         return new Promise((resolve) => {
-          resourcesService.getString(name, ...args).toPromise().then(message => {
+          getResourcesObservable(name, args).toPromise().then(message => {
             if (actual === message) {
               resolve({
                 pass: true
@@ -311,8 +299,7 @@ const asyncMatchers: jasmine.CustomAsyncMatcherFactories = {
             actual = actual.trim();
           }
 
-          const resourcesService: SkyAppResourcesService = TestBed.inject(SkyAppResourcesService);
-          resourcesService.getString(name, ...args).toPromise().then(message => {
+          getResourcesObservable(name, args).toPromise().then(message => {
             if (actual === message) {
               resolve({
                 pass: true
@@ -460,4 +447,13 @@ export function expect<T>(actual: T): SkyMatchers<T> {
  */
 export function expectAsync<T>(actual: T): SkyAsyncMatchers<T> {
   return windowRef.expectAsync(actual);
+}
+
+function getResourcesObservable(name: string, args: any[]): Observable<string> {
+  let resourcesService = TestBed.inject(SkyAppResourcesService);
+  if (args) {
+    return resourcesService.getString(name, ...args);
+  } else {
+    return resourcesService.getString(name);
+  }
 }

--- a/src/app/public/matchers/matchers.ts
+++ b/src/app/public/matchers/matchers.ts
@@ -186,7 +186,7 @@ const matchers: jasmine.CustomMatcherFactories = {
       ): jasmine.CustomMatcherResult {
 
         let skyAppResourcesService = TestBed.inject(SkyAppResourcesService);
-        skyAppResourcesService.getString(name, args).toPromise().then(message => {
+        skyAppResourcesService.getString(name, ...args).toPromise().then(message => {
           if (actual !== message) {
             windowRef.fail(`Expected "${actual}" to equal "${message}"`);
             callback();
@@ -224,7 +224,7 @@ const matchers: jasmine.CustomMatcherFactories = {
         }
 
         let skyAppResourcesService = TestBed.inject(SkyAppResourcesService);
-        skyAppResourcesService.getString(name, args).toPromise().then(message => {
+        skyAppResourcesService.getString(name, ...args).toPromise().then(message => {
           if (actual !== message) {
             windowRef.fail(`Expected element's inner text to be "${message}"`);
             callback();
@@ -279,7 +279,7 @@ const asyncMatchers: jasmine.CustomAsyncMatcherFactories = {
         const resourcesService: SkyAppResourcesService = TestBed.inject(SkyAppResourcesService);
 
         return new Promise((resolve) => {
-          resourcesService.getString(name, args).toPromise().then(message => {
+          resourcesService.getString(name, ...args).toPromise().then(message => {
             if (actual === message) {
               resolve({
                 pass: true
@@ -312,7 +312,7 @@ const asyncMatchers: jasmine.CustomAsyncMatcherFactories = {
           }
 
           const resourcesService: SkyAppResourcesService = TestBed.inject(SkyAppResourcesService);
-          resourcesService.getString(name, args).toPromise().then(message => {
+          resourcesService.getString(name, ...args).toPromise().then(message => {
             if (actual === message) {
               resolve({
                 pass: true


### PR DESCRIPTION
I'd love to write a test for this but the current tests (which I wrote) mock the call to the resources service so I'm not sure it's testable with out actually calling the resource service.