### PR TITLE
Release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.0 (2021-11-23)
+
+- Added support for tokenized resource matchers. [#60](https://github.com/blackbaud/skyux-sdk-testing/pull/60)
+
 # 5.0.1 (2021-11-19)
 
 - Updated the builder to support StackBlitz. [#59](https://github.com/blackbaud/skyux-sdk-testing/pull/59)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 5.1.0 (2021-11-23)
 
-- Added support for tokenized resource matchers. [#60](https://github.com/blackbaud/skyux-sdk-testing/pull/60)
+- Added support for tokenized resource matchers. [#60](https://github.com/blackbaud/skyux-sdk-testing/pull/60) (Thanks [@Blackbaud-ChrisMecklenborg](https://github.com/Blackbaud-ChrisMecklenborg)!)
 
 # 5.0.1 (2021-11-19)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4302,9 +4302,9 @@
       }
     },
     "@skyux/packages": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@skyux/packages/-/packages-5.58.0.tgz",
-      "integrity": "sha512-RcKMe8v8KO0PgXG5EKsXO5zYksG26Jc/PZ8UlU3Sxi2omK7/ntokJhaqTai2kEhJ6OPacyOgXuPEw8C5wjhCmQ==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/@skyux/packages/-/packages-5.76.0.tgz",
+      "integrity": "sha512-fAj/gUpa9Wyb1Cn666O6D/Jti59w9tnSugIljL2dkZmt/mygMTyEgMUf32+EWLKJLsa2tiq9FfbBoNM8QHEEHA==",
       "requires": {
         "latest-version": "5.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@angular/router": "12.2.13",
     "@blackbaud/auth-client": "2.50.0",
     "@skyux/i18n": "5.0.1",
-    "@skyux/packages": "5.58.0",
+    "@skyux/packages": "5.76.0",
     "axe-core": "3.5.6",
     "rxjs": "6.6.7",
     "tslib": "2.3.1",

--- a/projects/testing/package.json
+++ b/projects/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux-sdk/testing",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "peerDependencies": {
     "@angular/common": "^12.2.13",
     "@angular/core": "^12.2.13",


### PR DESCRIPTION
- Added support for tokenized resource matchers. [#60](https://github.com/blackbaud/skyux-sdk-testing/pull/60)